### PR TITLE
Replace the inactive mail listing with the new forum

### DIFF
--- a/index.org
+++ b/index.org
@@ -26,7 +26,7 @@
 * 各种各样的联系方式
 + 这个站点的 [[https://github.com/emacs-china/emacs-china.github.io/issues][issues]] （github 的 issues 功能实际上能拿来当论坛用了）
 + gitter（emacs-china 成员内部使用） : [[https://gitter.im/emacs-china][点击我]]
-+ email : [[https://groups.google.com/group/emacs-china][emacs-china 邮件列表]]
++ 论坛 : https://emacs-china.org/
 + IRC : （待添加）
 + QQ 群 : 59134186
 


### PR DESCRIPTION
邮件列表很长时间以来完全没有讨论，还是有人时不时地申请加入这个邮件列表，我觉得加进来也没什么意义。

_另外，如果有人想接管这个邮件列表，请告知我，我可以把它的所有权转移给你。_
